### PR TITLE
Use CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Install to the build directory
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING "CMake install prefix" FORCE)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING "CMake install prefix" FORCE)
+endif()
 
 # Use "d" suffix for debug builds
 # Do not use a suffix for RelWithDebInfo


### PR DESCRIPTION
This lets us set the install prefix to the build directory *unless* the user has explicitly provided something else. Before this commit, it was impossible to change the install prefix.