### PR TITLE
Remove Pipeline Executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Version 2.2.0
+
+This is a major change to the underlying code to remove the deprecated `pdal::PipelineExecutor` and replace it with `pdal::PipelineManager`.
+
+This version also introduces the following non-breaking changes to the ABI:
+
+- Addition of the following method to allow the consuming app to tell if a pipeline is streamable:
+
+```
+bool PDALPipelineIsStreamable(PDALPipelinePtr pipeline)
+```
+
+- Addition of the following method to allow the consuming application to run a pipeline in streaming mode. If the pipeline is non-streamable it will be silently run in standard mode:
+
+```
+bool PDALExecutePipelineAsStream(PDALPipelinePtr pipeline)
+```
+
+
 # Version 2.1.1
 
 Changes to allow compilation with PDAL 2.4.0

--- a/source/pdal/pdalc_config.cpp
+++ b/source/pdal/pdalc_config.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+#define _CRT_SECURE_NO_WARNINGS
 #include "pdalc_config.h"
 
 #include <cstdlib>
@@ -35,6 +36,8 @@
 
 #include <pdal/pdal_config.hpp>
 #include <pdal/util/Utils.hpp>
+
+
 
 namespace pdal
 {

--- a/source/pdal/pdalc_config.h
+++ b/source/pdal/pdalc_config.h
@@ -32,6 +32,7 @@
 
 #include "pdalc_forward.h"
 
+
 /**
  * @file pdalc_config.h
  * Functions to retrieve PDAL version and configuration information.

--- a/source/pdal/pdalc_dimtype.cpp
+++ b/source/pdal/pdalc_dimtype.cpp
@@ -26,10 +26,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
-
+#define _CRT_SECURE_NO_WARNINGS
 #include "pdal/pdalc_dimtype.h"
 
 #include <pdal/DimType.hpp>
+
+
 
 namespace pdal
 {

--- a/source/pdal/pdalc_forward.h
+++ b/source/pdal/pdalc_forward.h
@@ -68,15 +68,6 @@ using PointView = pdal::PointViewPtr;
 using TriangularMesh = pdal::MeshPtr;
 using DimTypeList = std::unique_ptr<pdal::DimTypeList>;
 
-struct Pipeline {
-    public:
-
-        std::unique_ptr<pdal::PipelineManager> manager = std::make_unique<pdal::PipelineManager>();
-
-        bool m_executed = false;
-        std::stringstream logStream;
-        pdal::LogLevel logLevel;
-    };
 }
 }
 

--- a/source/pdal/pdalc_forward.h
+++ b/source/pdal/pdalc_forward.h
@@ -53,7 +53,7 @@
 namespace pdal
 {
 struct DimType;
-class PipelineExecutor;
+class PipelineManager;
 class PointView;
 class TriangularMesh;
 
@@ -64,10 +64,19 @@ using MeshPtr = std::shared_ptr<TriangularMesh>;
 namespace capi
 {
 class PointViewIterator;
-using Pipeline = std::unique_ptr<pdal::PipelineExecutor>;
 using PointView = pdal::PointViewPtr;
 using TriangularMesh = pdal::MeshPtr;
 using DimTypeList = std::unique_ptr<pdal::DimTypeList>;
+
+struct Pipeline {
+    public:
+
+        std::unique_ptr<pdal::PipelineManager> manager = std::make_unique<pdal::PipelineManager>();
+
+        bool m_executed = false;
+        std::stringstream logStream;
+        pdal::LogLevel logLevel;
+    };
 }
 }
 

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -115,8 +115,10 @@ extern "C"
 
                 std::stringstream strm;
                 pdal::PipelineWriter::writePipeline(ptr->manager->getStage(), strm);
-                strm.get(buffer, size);
-                return std::min(static_cast<size_t>(strm.gcount()), size);
+                std::string out = strm.str();
+                if (out.length() > size - 1) out.resize(size - 1);
+                std::strncpy(buffer, out.c_str(), size);
+                return std::min(out.length() + 1, size);
             }
             catch (const std::exception &e)
             {
@@ -141,8 +143,10 @@ extern "C"
                 std::stringstream strm;
                 MetadataNode root = ptr->manager->getMetadata().clone("metadata");
                 pdal::Utils::toJSON(root, strm);
-                strm.get(metadata, size);
-                return std::min(static_cast<size_t>(strm.gcount()), size);
+                std::string out = strm.str();
+                if (out.length() > size - 1) out.resize(size - 1);
+                std::strncpy(metadata, out.c_str(), size);
+                return std::min(out.length() + 1, size);
             }
             catch (const std::exception &e)
             {
@@ -165,8 +169,10 @@ extern "C"
                 MetadataNode meta = ptr->manager->pointTable().layout()->toMetadata();
                 MetadataNode root = meta.clone("schema");
                 pdal::Utils::toJSON(root, strm);
-                strm.get(schema, size);
-                return std::min(static_cast<size_t>(strm.gcount()), size);
+                std::string out = strm.str();
+                if (out.length() > size - 1) out.resize(size - 1);
+                std::strncpy(schema, out.c_str(), size);
+                return std::min(out.length() + 1, size);
             }
             catch (const std::exception &e)
             {

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -46,13 +46,14 @@ namespace capi
 
 extern "C"
 {
-    struct Pipeline {
-        public:
+    struct Pipeline
+    {
+    public:
 
-            PipelineManagerPtr manager = std::make_unique<PipelineManager>();
+        PipelineManagerPtr manager = std::make_unique<PipelineManager>();
 
-            bool m_executed = false;
-            std::stringstream logStream;
+        bool m_executed = false;
+        std::stringstream logStream;
     };
 
     PDALPipelinePtr PDALCreatePipeline(const char* json)
@@ -113,9 +114,9 @@ extern "C"
 
             try
             {
-                if ( ! ptr->m_executed)
+                if (! ptr->m_executed)
                     throw pdal_error("Pipeline has not been executed!");
-                
+
                 std::stringstream strm;
                 pdal::PipelineWriter::writePipeline(ptr->manager->getStage(), strm);
                 std::strncpy(buffer, strm.str().c_str(), size - 1);
@@ -142,9 +143,9 @@ extern "C"
 
             try
             {
-                if ( ! ptr->m_executed)
+                if (! ptr->m_executed)
                     throw pdal_error("Pipeline has not been executed!");
-                
+
                 std::stringstream strm;
                 MetadataNode root = ptr->manager->getMetadata().clone("metadata");
                 pdal::Utils::toJSON(root, strm);
@@ -217,8 +218,8 @@ extern "C"
     {
         Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
 
-        try 
-        { 
+        try
+        {
             if (level < 0 || level > 8)
                 throw pdal_error("log level must be between 0 and 8!");
 
@@ -227,7 +228,7 @@ extern "C"
         }
         catch (const std::exception &e)
         {
-        printf("Found error while setting log level: %s\n", e.what());
+            printf("Found error while setting log level: %s\n", e.what());
         }
 
     }
@@ -237,13 +238,15 @@ extern "C"
         Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
         try
         {
-            return (ptr) 
-                ? static_cast<int>(
-                    ptr->manager->log()->getLevel()
-                ) : 0;
+            return (ptr)
+                   ? static_cast<int>(
+                       ptr->manager->log()->getLevel()
+                   ) : 0;
         }
         catch (const std::exception &e)
-        {printf("Found error while getting log level: %s\n", e.what()); }
+        {
+            printf("Found error while getting log level: %s\n", e.what());
+        }
         return 0;
     }
 

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -98,7 +98,8 @@ extern "C"
     {
         if (pipeline)
         {
-            delete pipeline;
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+            delete ptr;
         }
     }
 

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -36,6 +36,7 @@
 #include <pdal/util/Utils.hpp>
 #include <pdal/PipelineWriter.hpp>
 #include <pdal/Stage.hpp>
+#include <pdal/pdal_types.hpp>
 
 #undef min
 
@@ -270,6 +271,40 @@ extern "C"
         }
         return result;
     }
+
+    bool PDALExecutePipelineAsStream(PDALPipelinePtr pipeline)
+    {
+        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+
+        if (ptr)
+        {
+            try
+            {
+                PipelineManager::ExecResult exec = ptr->manager->execute(ExecMode::Stream);
+                ptr->m_executed = true;
+                return true;
+            }
+            catch (const std::exception &e)
+            {
+                printf("Found error while executing pipeline: %s", e.what());
+                return false;
+            }
+        }
+        return false;
+    }
+
+    bool PDALPipelineIsStreamable(PDALPipelinePtr pipeline)
+    {
+        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+
+        if (ptr)
+        {
+            return ptr->manager->pipelineStreamable();
+        }
+        return false;
+    }
+
+
 
     bool PDALValidatePipeline(PDALPipelinePtr pipeline)
     {

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -59,7 +59,7 @@ extern "C"
 
     PDALPipelinePtr PDALCreatePipeline(const char* json)
     {
-        Pipeline* pipeline = new Pipeline();
+        std::unique_ptr<Pipeline> pipeline = std::make_unique<Pipeline>();
         if (json && std::strlen(json) > 0)
         {
             try
@@ -75,7 +75,6 @@ extern "C"
             catch (const std::exception &e)
             {
                 printf("Could not create pipeline: %s\n%s\n", e.what(), json);
-                delete pipeline;
                 return nullptr;
             }
 
@@ -86,11 +85,10 @@ extern "C"
             catch (const std::exception &e)
             {
                 printf("Error while validating pipeline: %s\n%s\n", e.what(), json);
-                delete pipeline;
                 return nullptr;
             }
 
-            return pipeline;
+            return pipeline.release();
         }
         return nullptr;
     }

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -167,7 +167,7 @@ extern "C"
             {
                 if (! ptr->m_executed)
                     throw pdal_error("Pipeline has not been executed!");
-                
+
                 std::stringstream strm;
                 MetadataNode meta = ptr->manager->pointTable().layout()->toMetadata();
                 MetadataNode root = meta.clone("schema");

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -134,7 +134,6 @@ extern "C"
 
     size_t PDALGetPipelineMetadata(PDALPipelinePtr pipeline, char *metadata, size_t size)
     {
-        std::cout << "get metadata starts"<< std::endl;
         size_t result = 0;
 
         if (pipeline && metadata && size > 0)

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -44,8 +44,19 @@ namespace pdal
 {
 namespace capi
 {
+
 extern "C"
 {
+    struct Pipeline {
+        public:
+
+            std::unique_ptr<pdal::PipelineManager> manager = std::make_unique<pdal::PipelineManager>();
+
+            bool m_executed = false;
+            std::stringstream logStream;
+            pdal::LogLevel logLevel;
+    };
+
     PDALPipelinePtr PDALCreatePipeline(const char* json)
     {
         PDALPipelinePtr pipeline = new Pipeline();

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -215,10 +215,9 @@ extern "C"
 
     void PDALSetPipelineLogLevel(PDALPipelinePtr pipeline, int level)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-
         try
         {
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
             if (level < 0 || level > 8)
                 throw pdal_error("log level must be between 0 and 8!");
 
@@ -229,14 +228,16 @@ extern "C"
         {
             printf("Found error while setting log level: %s\n", e.what());
         }
-
     }
 
     int PDALGetPipelineLogLevel(PDALPipelinePtr pipeline)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+        if (! pipeline)
+            return 0;
+
         try
         {
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
             return (ptr)
                    ? static_cast<int>(
                        ptr->manager->log()->getLevel()
@@ -251,100 +252,88 @@ extern "C"
 
     int64_t PDALExecutePipeline(PDALPipelinePtr pipeline)
     {
-        int64_t result = 0;
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+        if (! pipeline)
+            return 0;
 
-        if (ptr)
+        try
         {
-            try
-            {
-                result = ptr->manager->execute();
-                ptr->m_executed = true;
-            }
-            catch (const std::exception &e)
-            {
-                printf("Found error while executing pipeline: %s", e.what());
-            }
+            int64_t result;
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+            result = ptr->manager->execute();
+            ptr->m_executed = true;
+            return result;
         }
-        return result;
+        catch (const std::exception &e)
+        {
+            printf("Found error while executing pipeline: %s", e.what());
+            return 0;
+        }
     }
 
     bool PDALExecutePipelineAsStream(PDALPipelinePtr pipeline)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+        if (! pipeline)
+            return false;
 
-        if (ptr)
+        try
         {
-            try
-            {
-                PipelineManager::ExecResult exec = ptr->manager->execute(ExecMode::Stream);
-                ptr->m_executed = true;
-                return true;
-            }
-            catch (const std::exception &e)
-            {
-                printf("Found error while executing pipeline: %s", e.what());
-                return false;
-            }
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+            PipelineManager::ExecResult exec = ptr->manager->execute(ExecMode::Stream);
+            ptr->m_executed = true;
+            return true;
         }
-        return false;
+        catch (const std::exception &e)
+        {
+            printf("Found error while executing pipeline: %s", e.what());
+            return false;
+        }
     }
 
     bool PDALPipelineIsStreamable(PDALPipelinePtr pipeline)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+        if (! pipeline)
+            return false;
 
-        if (ptr)
-        {
-            return ptr->manager->pipelineStreamable();
-        }
-        return false;
+        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+        return ptr->manager->pipelineStreamable();
     }
 
 
 
     bool PDALValidatePipeline(PDALPipelinePtr pipeline)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-
-        if (ptr)
+        if (! pipeline)
+            return false;
+        try
         {
-            try
-            {
-                ptr->manager->prepare();
-                return true;
-            }
-            catch (const std::exception &e)
-            {
-                printf("Found error while validating pipeline: %s", e.what());
-                return false;
-            }
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+            ptr->manager->prepare();
+            return true;
         }
-        return false;
+        catch (const std::exception &e)
+        {
+            printf("Found error while validating pipeline: %s", e.what());
+            return false;
+        }
     }
 
     PDALPointViewIteratorPtr PDALGetPointViews(PDALPipelinePtr pipeline)
     {
-        Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-        pdal::capi::PointViewIterator *views = nullptr;
+        if (! pipeline)
+            return nullptr;
 
-        if (ptr)
+        try
         {
-            try
-            {
-                views = new pdal::capi::PointViewIterator(ptr->manager->views());
-            }
-            catch (const std::exception &e)
-            {
-                printf("Found error while retrieving point views: %s\n", e.what());
-            }
+            Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
+            return new pdal::capi::PointViewIterator(ptr->manager->views());
         }
-
-        return views;
+        catch (const std::exception &e)
+        {
+            printf("Found error while retrieving point views: %s\n", e.what());
+            return nullptr;
+        }
     }
+
 } /* extern c */
-
-
-
 } /* capi */
 } /* pdal */

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -118,7 +118,7 @@ extern "C"
                 std::string out = strm.str();
                 if (out.length() > size - 1) out.resize(size - 1);
                 std::strncpy(buffer, out.c_str(), size);
-                return std::min(out.length() + 1, size);
+                return strlen(out.c_str());
             }
             catch (const std::exception &e)
             {
@@ -146,7 +146,7 @@ extern "C"
                 std::string out = strm.str();
                 if (out.length() > size - 1) out.resize(size - 1);
                 std::strncpy(metadata, out.c_str(), size);
-                return std::min(out.length() + 1, size);
+                return strlen(out.c_str());
             }
             catch (const std::exception &e)
             {
@@ -165,6 +165,9 @@ extern "C"
 
             try
             {
+                if (! ptr->m_executed)
+                    throw pdal_error("Pipeline has not been executed!");
+                
                 std::stringstream strm;
                 MetadataNode meta = ptr->manager->pointTable().layout()->toMetadata();
                 MetadataNode root = meta.clone("schema");
@@ -172,7 +175,7 @@ extern "C"
                 std::string out = strm.str();
                 if (out.length() > size - 1) out.resize(size - 1);
                 std::strncpy(schema, out.c_str(), size);
-                return std::min(out.length() + 1, size);
+                return strlen(out.c_str());
             }
             catch (const std::exception &e)
             {

--- a/source/pdal/pdalc_pipeline.cpp
+++ b/source/pdal/pdalc_pipeline.cpp
@@ -104,13 +104,9 @@ extern "C"
 
     size_t PDALGetPipelineAsString(PDALPipelinePtr pipeline, char *buffer, size_t size)
     {
-        size_t result = 0;
-
         if (pipeline && buffer && size > 0)
         {
             Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-            buffer[0] =  '\0';
-            buffer[size - 1] = '\0';
 
             try
             {
@@ -119,26 +115,23 @@ extern "C"
 
                 std::stringstream strm;
                 pdal::PipelineWriter::writePipeline(ptr->manager->getStage(), strm);
-                std::strncpy(buffer, strm.str().c_str(), size - 1);
-                result = std::min(strm.str().length(), size);
+                strm.get(buffer, size);
+                return std::min(static_cast<size_t>(strm.gcount()), size);
             }
             catch (const std::exception &e)
             {
                 printf("Found error while retrieving pipeline's string representation: %s\n", e.what());
+                return 0;
             }
         }
-        return result;
+        return 0;
     }
 
     size_t PDALGetPipelineMetadata(PDALPipelinePtr pipeline, char *metadata, size_t size)
     {
-        size_t result = 0;
-
         if (pipeline && metadata && size > 0)
         {
             Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-            metadata[0] =  '\0';
-            metadata[size - 1] = '\0';
 
             try
             {
@@ -148,27 +141,23 @@ extern "C"
                 std::stringstream strm;
                 MetadataNode root = ptr->manager->getMetadata().clone("metadata");
                 pdal::Utils::toJSON(root, strm);
-                std::strncpy(metadata, strm.str().c_str(), size);
-                result = std::min(strm.str().length(), size);
+                strm.get(metadata, size);
+                return std::min(static_cast<size_t>(strm.gcount()), size);
             }
             catch (const std::exception &e)
             {
                 printf("Found error while retrieving pipeline's metadata: %s\n", e.what());
+                return 0;
             }
         }
-        return result;
+        return 0;
     }
 
     size_t PDALGetPipelineSchema(PDALPipelinePtr pipeline, char *schema, size_t size)
     {
-        size_t result = 0;
-
         if (pipeline && schema && size > 0)
         {
             Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-
-            schema[0] =  '\0';
-            schema[size - 1] = '\0';
 
             try
             {
@@ -176,41 +165,38 @@ extern "C"
                 MetadataNode meta = ptr->manager->pointTable().layout()->toMetadata();
                 MetadataNode root = meta.clone("schema");
                 pdal::Utils::toJSON(root, strm);
-                std::strncpy(schema, strm.str().c_str(), size);
-                result = std::min(strm.str().length(), size);
+                strm.get(schema, size);
+                return std::min(static_cast<size_t>(strm.gcount()), size);
             }
             catch (const std::exception &e)
             {
                 printf("Found error while retrieving pipeline's schema: %s\n", e.what());
+                return 0;
             }
 
         }
-        return result;
+        return 0;
     }
 
     size_t PDALGetPipelineLog(PDALPipelinePtr pipeline, char *log, size_t size)
     {
-        size_t result = 0;
-
         if (pipeline && log && size > 0)
         {
             Pipeline *ptr = reinterpret_cast<Pipeline *>(pipeline);
-            log[0] =  '\0';
-            log[size - 1] = '\0';
 
             try
             {
-                std::string s = ptr->logStream.str();
-                std::strncpy(log, s.c_str(), size);
-                result = std::min(s.length(), size);
+                ptr->logStream.get(log, size);
+                return std::min(static_cast<size_t>(ptr->logStream.gcount()), size);
             }
             catch (const std::exception &e)
             {
                 printf("Found error while retrieving pipeline's log: %s\n", e.what());
+                return 0;
             }
         }
 
-        return result;
+        return 0;
     }
 
     void PDALSetPipelineLogLevel(PDALPipelinePtr pipeline, int level)

--- a/source/pdal/pdalc_pipeline.h
+++ b/source/pdal/pdalc_pipeline.h
@@ -32,6 +32,7 @@
 
 #include "pdalc_forward.h"
 
+
 /**
  * @file pdalc_pipeline.h
  * Functions to launch and inspect the results of a PDAL pipeline.
@@ -45,6 +46,7 @@ namespace capi
 {
 extern "C"
 {
+
 #else
 #include <stdbool.h> // for bool
 #include <stddef.h> // for size_t
@@ -157,9 +159,6 @@ PDALC_API PDALPointViewIteratorPtr PDALGetPointViews(PDALPipelinePtr pipeline);
 #ifdef __cplusplus
 
 } /* extern C */
-
-
-
 } /* capi*/
 } /* pdal*/
 #endif /* _cplusplus */

--- a/source/pdal/pdalc_pipeline.h
+++ b/source/pdal/pdalc_pipeline.h
@@ -140,7 +140,7 @@ PDALC_API int64_t PDALExecutePipeline(PDALPipelinePtr pipeline);
  * Executes a pipeline as a streamable pipeline. Will run as non-streamed pipeline if the pipeline is not streamable.
  *
  * @param pipeline The pipeline
- * @return The total number of points produced by the pipeline
+ * @return true for success
  */
 PDALC_API bool PDALExecutePipelineAsStream(PDALPipelinePtr pipeline);
 

--- a/source/pdal/pdalc_pipeline.h
+++ b/source/pdal/pdalc_pipeline.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2019, Simverge Software LLC. All rights reserved.
+ * Copyright (c) 2019, Simverge Software LLC & Runette Software. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following
@@ -156,8 +156,11 @@ PDALC_API PDALPointViewIteratorPtr PDALGetPointViews(PDALPipelinePtr pipeline);
 
 #ifdef __cplusplus
 
-}
-}
-}
+} /* extern C */
+
+
+
+} /* capi*/
+} /* pdal*/
 #endif /* _cplusplus */
 #endif /* PDALC_PIPELINE_H */

--- a/source/pdal/pdalc_pipeline.h
+++ b/source/pdal/pdalc_pipeline.h
@@ -137,6 +137,22 @@ PDALC_API int PDALGetPipelineLogLevel(PDALPipelinePtr pipeline);
 PDALC_API int64_t PDALExecutePipeline(PDALPipelinePtr pipeline);
 
 /**
+ * Executes a pipeline as a streamable pipeline. Will run as non-streamed pipeline if the pipeline is not streamable.
+ *
+ * @param pipeline The pipeline
+ * @return The total number of points produced by the pipeline
+ */
+PDALC_API bool PDALExecutePipelineAsStream(PDALPipelinePtr pipeline);
+
+/**
+ * Determines if a pipeline is streamable
+ *
+ * @param pipeline The pipeline
+ * @return Whether the pipeline is streamable
+ */
+PDALC_API bool PDALPipelineIsStreamable(PDALPipelinePtr pipeline);
+
+/**
  * Validates a pipeline.
  *
  * @param pipeline The pipeline

--- a/source/pdal/pdalc_pointview.cpp
+++ b/source/pdal/pdalc_pointview.cpp
@@ -26,7 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
-
+#define _CRT_SECURE_NO_WARNINGS
 #include "pdalc_pointview.h"
 
 #include <pdal/PointView.hpp>

--- a/tests/pdal/test_pdalc_config.c
+++ b/tests/pdal/test_pdalc_config.c
@@ -114,12 +114,12 @@ TEST testPDALVersionInfo(void)
 
     int patch = PDALVersionPatch();
 
-    char expected[64];
+    char expected[128];
     sprintf(expected, "%d.%d.%d", major, minor, patch);
 
-    char version[64];
-    size_t size = PDALVersionString(version, 64);
-    ASSERT(size > 0 && size <= 64);
+    char version[128];
+    size_t size = PDALVersionString(version, 128);
+    ASSERT(size > 0 && size <= 128);
     ASSERT(version[0]);
     ASSERT_STR_EQ(expected, version);
 
@@ -140,7 +140,7 @@ TEST testPDALVersionInfo(void)
         sha1[6] = '\0';
     }
 
-    snprintf(expected + strlen(version), " (git-version: %s)", sha1);
+    sprintf(expected + strlen(version), " (git-version: %s)", sha1);
 
     char fullVersion[64];
     size = PDALFullVersionString(fullVersion, 64);

--- a/tests/pdal/test_pdalc_config.c
+++ b/tests/pdal/test_pdalc_config.c
@@ -114,12 +114,12 @@ TEST testPDALVersionInfo(void)
 
     int patch = PDALVersionPatch();
 
-    char expected[64];
-    sprintf(expected, "%d.%d.%d", major, minor, patch);
+    char expected[128];
+    snprintf(expected, "%d.%d.%d", major, minor, patch);
 
-    char version[64];
-    size_t size = PDALVersionString(version, 64);
-    ASSERT(size > 0 && size <= 64);
+    char version[128];
+    size_t size = PDALVersionString(version, 128);
+    ASSERT(size > 0 && size <= 128);
     ASSERT(version[0]);
     ASSERT_STR_EQ(expected, version);
 

--- a/tests/pdal/test_pdalc_config.c
+++ b/tests/pdal/test_pdalc_config.c
@@ -114,12 +114,12 @@ TEST testPDALVersionInfo(void)
 
     int patch = PDALVersionPatch();
 
-    char expected[128];
-    snprintf(expected, "%d.%d.%d", major, minor, patch);
+    char expected[64];
+    sprintf(expected, "%d.%d.%d", major, minor, patch);
 
-    char version[128];
-    size_t size = PDALVersionString(version, 128);
-    ASSERT(size > 0 && size <= 128);
+    char version[64];
+    size_t size = PDALVersionString(version, 64);
+    ASSERT(size > 0 && size <= 64);
     ASSERT(version[0]);
     ASSERT_STR_EQ(expected, version);
 

--- a/tests/pdal/test_pdalc_config.c
+++ b/tests/pdal/test_pdalc_config.c
@@ -140,7 +140,7 @@ TEST testPDALVersionInfo(void)
         sha1[6] = '\0';
     }
 
-    sprintf(expected + strlen(version), " (git-version: %s)", sha1);
+    snprintf(expected + strlen(version), " (git-version: %s)", sha1);
 
     char fullVersion[64];
     size = PDALFullVersionString(fullVersion, 64);

--- a/tests/pdal/test_pdalc_pipeline.c.in
+++ b/tests/pdal/test_pdalc_pipeline.c.in
@@ -149,7 +149,7 @@ TEST testPDALGetPipelineAsString(void)
     char json10[10];
     size = PDALGetPipelineAsString(pipeline, json10, 10);
 
-    if (size != 9 )
+    if (size != 9)
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;
@@ -220,7 +220,7 @@ TEST testPDALGetPipelineMetadata(void)
     char json10[10];
     size = PDALGetPipelineMetadata(pipeline, json10, 10);
 
-    if (size != 9 )
+    if (size != 9)
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;
@@ -284,7 +284,7 @@ TEST testPDALGetPipelineSchema(void)
     char json10[10];
     size = PDALGetPipelineSchema(pipeline, json10, 10);
 
-    if (size != 9 )
+    if (size != 9)
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;

--- a/tests/pdal/test_pdalc_pipeline.c.in
+++ b/tests/pdal/test_pdalc_pipeline.c.in
@@ -344,6 +344,31 @@ TEST testPDALExecutePipeline(void)
     PASS();
 }
 
+TEST testPDALExecutePipelineStream(void)
+{
+    PDALPipelinePtr pipeline = PDALCreatePipeline(gPipelineJson);
+    ASSERT(pipeline);
+
+    bool isStreamable = PDALPipelineIsStreamable(pipeline);
+
+    ASSERT_EQ(isStreamable, true);
+
+    bool result = PDALExecutePipelineAsStream(pipeline);
+
+    ASSERT_EQ(result, true);
+
+    result = PDALExecutePipelineAsStream(NULL);
+
+    ASSERT_EQ(result, false);
+
+    isStreamable = PDALPipelineIsStreamable(NULL);
+
+    ASSERT_EQ(isStreamable, false);
+
+    PDALDisposePipeline(pipeline);
+    PASS();
+}
+
 TEST testPDALValidatePipeline(void)
 {
     bool valid = PDALValidatePipeline(NULL);
@@ -369,6 +394,7 @@ GREATEST_SUITE(test_pdalc_pipeline)
 
     RUN_TEST(testPDALCreateAndDisposePipeline);
     RUN_TEST(testPDALExecutePipeline);
+    RUN_TEST(testPDALExecutePipelineStream);
     RUN_TEST(testPDALGetSetPipelineLog);
     RUN_TEST(testPDALGetPipelineAsString);
     RUN_TEST(testPDALGetPipelineMetadata);

--- a/tests/pdal/test_pdalc_pipeline.c.in
+++ b/tests/pdal/test_pdalc_pipeline.c.in
@@ -146,6 +146,23 @@ TEST testPDALGetPipelineAsString(void)
         FAILm("PDALGetPipelineMetadata generated a JSON string whose object name is not \"pipeline\"");
     }
 
+    char json10[10];
+    size = PDALGetPipelineAsString(pipeline, json10, 10);
+
+    if (size != 10 )
+    {
+        PDALDisposePipeline(pipeline);
+        pipeline = NULL;
+        FAILm("PDALGetPipelineAsString truncation not working");
+    }
+
+    if (json[0] == '\0')
+    {
+        PDALDisposePipeline(pipeline);
+        pipeline = NULL;
+        FAILm("PDALGetPipelineAsString generated a JSON string whose first character is null");
+    }
+
     PDALDisposePipeline(pipeline);
     PASS();
 }
@@ -200,6 +217,16 @@ TEST testPDALGetPipelineMetadata(void)
         FAILm("PDALGetPipelineMetadata generated a JSON string whose object name is not \"schema\"");
     }
 
+    char json10[10];
+    size = PDALGetPipelineMetadata(pipeline, json10, 10);
+
+    if (size != 10 )
+    {
+        PDALDisposePipeline(pipeline);
+        pipeline = NULL;
+        FAILm("PDALGetPipelineMetadata truncation not working");
+    }
+
     PDALDisposePipeline(pipeline);
     PASS();
 }
@@ -252,6 +279,16 @@ TEST testPDALGetPipelineSchema(void)
         PDALDisposePipeline(pipeline);
         pipeline = NULL;
         FAILm("PDALGetPipelineSchema generated a JSON string whose object name is not \"schema\"");
+    }
+
+    char json10[10];
+    size = PDALGetPipelineSchema(pipeline, json10, 10);
+
+    if (size != 10 )
+    {
+        PDALDisposePipeline(pipeline);
+        pipeline = NULL;
+        FAILm("PDALGetPipelineSchema truncation not working");
     }
 
     PDALDisposePipeline(pipeline);

--- a/tests/pdal/test_pdalc_pipeline.c.in
+++ b/tests/pdal/test_pdalc_pipeline.c.in
@@ -149,7 +149,7 @@ TEST testPDALGetPipelineAsString(void)
     char json10[10];
     size = PDALGetPipelineAsString(pipeline, json10, 10);
 
-    if (size != 10 )
+    if (size != 9 )
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;
@@ -220,7 +220,7 @@ TEST testPDALGetPipelineMetadata(void)
     char json10[10];
     size = PDALGetPipelineMetadata(pipeline, json10, 10);
 
-    if (size != 10 )
+    if (size != 9 )
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;
@@ -284,7 +284,7 @@ TEST testPDALGetPipelineSchema(void)
     char json10[10];
     size = PDALGetPipelineSchema(pipeline, json10, 10);
 
-    if (size != 10 )
+    if (size != 9 )
     {
         PDALDisposePipeline(pipeline);
         pipeline = NULL;

--- a/tests/pdal/test_pdalc_pointlayout.c.in
+++ b/tests/pdal/test_pdalc_pointlayout.c.in
@@ -129,14 +129,14 @@ TEST testPDALFindDimType(void)
         success &= (PDALGetDimTypeIdName(expected, name, 64) > 0);
 
         actual = PDALFindDimType(NULL, name);
-        success &= (idUnknown == actual.id); 
+        success &= (idUnknown == actual.id);
         success &= (typeNone == actual.type);
 
         success &= (fabs(1.0 - actual.scale) < tolerance);
         success &= (fabs(actual.offset) < tolerance);
 
         actual = PDALFindDimType(gLayout, name);
-        success &= (expected.id == actual.id); 
+        success &= (expected.id == actual.id);
         success &= (expected.type == actual.type);
 
         success &= (fabs(expected.scale - actual.scale) < tolerance);

--- a/tests/pdal/test_pdalc_pointview.c.in
+++ b/tests/pdal/test_pdalc_pointview.c.in
@@ -166,7 +166,7 @@ TEST testPDALGetPointViewSize(void)
     PDALDisposePointView(view);
     ASSERT(size > 0);
 
-    
+
     PASS();
 }
 
@@ -189,7 +189,7 @@ TEST testPDALGetMeshSize(void)
     PDALDisposePointView(view);
     ASSERT(size == 2114);
 
-    
+
     PASS();
 }
 
@@ -538,7 +538,7 @@ TEST testPDALGetPackedPoint(void)
 
             size_t expected = (hasView && hasDims && hasBuffer ? layoutPointSize : 0);
             size_t actual = PDALGetPackedPoint(
-                hasView ? view : NULL, hasDims ? dims : NULL, i, hasBuffer ? buffer : NULL);
+                                hasView ? view : NULL, hasDims ? dims : NULL, i, hasBuffer ? buffer : NULL);
 
             if (expected != actual)
             {


### PR DESCRIPTION
Changes to Move from pdal::PipelineExector to pdal::PipelineManager since the former is deprecated.

Also - extended the ABI to include streamable execution.