### PR TITLE
Added ability to build static library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ make
 make install
 ```
 
+Setting `-DBUILD_SHARED_LIBS=OFF` enables the generation of a static (`.a`) library. 
+
 ## Code Style
 
 This project enforces the PDAL code styles, which can checked as follows :

--- a/source/pdal/CMakeLists.txt
+++ b/source/pdal/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(TARGET pdalc)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 find_package(PDAL REQUIRED CONFIG)
 message(STATUS "Found PDAL ${PDAL_VERSION}")
 
@@ -38,7 +40,7 @@ include_directories(
 
 add_definitions(${PDAL_DEFINITIONS})
 
-add_library(${TARGET} SHARED ${SOURCES} ${HEADERS})
+add_library(${TARGET} ${SOURCES} ${HEADERS})
 
 string(TOUPPER "${TARGET}_BUILD_DLL" BUILD_SYMBOL)
 


### PR DESCRIPTION
Setting `-DBUILD_SHARED_LIBS=OFF` enables the generation of a static (`.a`) library.